### PR TITLE
Fix Swift support

### DIFF
--- a/ios/hooks/ti.swiftsupport.js
+++ b/ios/hooks/ti.swiftsupport.js
@@ -1,0 +1,35 @@
+/**
+ * Ti.SwiftSupport
+ * Copyright (c) 2017-present by Axway Appcelerator
+ * All Rights Reserved.
+ */
+
+'use strict';
+
+exports.id = 'ti.swiftsupport';
+exports.cliVersion = '>=3.2';
+exports.init = init;
+
+/**
+ * Main entry point for our plugin which looks for the platform specific
+ * plugin to invoke
+ */
+function init(logger, config, cli, appc) {
+	cli.on('build.ios.xcodeproject', {
+		pre: function(data) {
+			logger.info('Enabling Swift support ...');
+
+			var xobjs = data.args[0].hash.project.objects;
+															
+			Object.keys(xobjs.PBXNativeTarget).forEach(function (targetUuid) {
+				var target = xobjs.PBXNativeTarget[targetUuid];
+				if (target && typeof target === 'object') {
+					xobjs.XCConfigurationList[target.buildConfigurationList].buildConfigurations.forEach(function (buildConf) {
+						var buildSettings = xobjs.XCBuildConfiguration[buildConf.value].buildSettings;
+						buildSettings.ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = 'YES';
+					});
+				}
+			});
+		}
+	});
+}

--- a/ios/manifest
+++ b/ios/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 1.0.0
+version: 1.0.1
 apiversion: 2
 architectures: armv7 arm64 i386 x86_64
 description: Socket.io client for Titanium


### PR DESCRIPTION
Attempts to fix #6. Please test the attached version.

**NOTE**: This version is built with Swift 4.1. Because of Swift's still missing [ABI Stability](https://github.com/apple/swift/blob/master/docs/ABIStabilityManifesto.md) (work in progress), you need to have the same Swift version installed that is used by the Swift-based framework, in this case `Starscream.framework`.

[ti.socketio-iphone-1.0.1.zip](https://github.com/appcelerator-modules/titanium-socketio/files/2102720/ti.socketio-iphone-1.0.1.zip)
