### PR TITLE
fix(android): fix removing once event listeners after being called

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ library 'pipeline-library'
 buildModule {
 	sdkVersion = '9.0.0.v20200205142057'
 	githubPublish = false
+	iosLabels = 'osx && xcode-11'
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,6 +3,5 @@ library 'pipeline-library'
 
 buildModule {
 	sdkVersion = '9.0.0.v20200205142057'
-	githubPublish = false
 	iosLabels = 'osx && xcode-11'
 }

--- a/android/assets/ti.socketio.js
+++ b/android/assets/ti.socketio.js
@@ -68,8 +68,10 @@ function patchSocketPrototype(socket) {
 		},
 		once: {
 			value: function once(eventName, listener) {
-				this.on(eventName, function () {
-					this.off(eventName, listener);
+				// we *must* use the exact same listener function in on *and* off here, or else
+				// off never actually unregisters because there's a mismatch
+				this.on(eventName, function onceWrapper() {
+					this.off(eventName, onceWrapper); // MUST BE `onceWrapper` function, NOT original `listener`
 					listener.apply(null, arguments);
 				});
 				return this;

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.0
+version: 3.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: ti.socketio

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "titanium-socketio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "titanium-socketio",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Socket.io module for Titanium using native Android and iOS clients.",
   "private": true,
   "scripts": {

--- a/test/unit/specs/connection.spec.js
+++ b/test/unit/specs/connection.spec.js
@@ -4,92 +4,100 @@ const port = '3210';
 const url = `http://${host}:${port}`;
 
 describe('connection', () => {
+	let socket;
+	let manager;
+	afterEach(() => {
+		if (socket) {
+			socket.off(); // remove all listeners
+			if (socket.connected) {
+				socket.disconnect();
+			}
+		}
+		if (manager) {
+			manager.disconnect();
+		}
+	});
+
 	// this test needs to come first so no other existing managers interfere
 	it('should use single connection when connecting different namespaces', () => {
 		const s1 = io.connect(url);
 		const s2 = io.connect(url + '/foo');
 
-		expect(s1.io).toBe(s2.io);
-		s1.disconnect();
-		s2.disconnect();
+		try {
+			expect(s1.io).toBe(s2.io);
+		} finally {
+			s1.disconnect();
+			s2.disconnect();
+		}
 	});
 
 	it('should emit connect event on successful connect', done => {
-		const socket = io.connect(url, { forceNew: true, autoConnect: false });
-		socket.on('connect', () => {
-			socket.disconnect();
-			done();
-		});
+		socket = io.connect(url, { forceNew: true, autoConnect: false });
+		socket.on('connect', () => done());
 		socket.connect();
 	});
 
 	it('should emit error if host not reachable', done => {
-		const socket = io.connect('http://localhost:8080/', { forceNew: true });
-		socket.on('connect_error', () => {
-			socket.disconnect();
-			done();
-		});
+		socket = io.connect('http://localhost:8080/', { forceNew: true });
+		socket.on('connect_error', () => done());
 	});
 
 	it('should not connect when autoConnect option set to false', () => {
-		const socket = io.connect(url, { autoConnect: false, forceNew: true });
+		socket = io.connect(url, { autoConnect: false, forceNew: true });
+
 		expect(socket.connected).toBeFalsy();
-		socket.disconnect();
 	});
 
 	it('should start two connections with same path', () => {
 		const s1 = io.connect(url);
 		const s2 = io.connect(url);
 
-		expect(s1.io).not.toBe(s2.io);
-		s1.disconnect();
-		s2.disconnect();
+		try {
+			expect(s1.io).not.toBe(s2.io);
+		} finally {
+			s1.disconnect();
+			s2.disconnect();
+		}
 	});
 
 	it('should start two connections with same path and different querystrings', () => {
 		const s1 = io.connect(url + '/?woot');
 		const s2 = io.connect(url + '/');
 
-		expect(s1.io).not.toBe(s2.io);
-		s1.disconnect();
-		s2.disconnect();
+		try {
+			expect(s1.io).not.toBe(s2.io);
+		} finally {
+			s1.disconnect();
+			s2.disconnect();
+		}
 	});
 
 	xit('should work with acks', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.on('ack', function (fn) {
 			fn(5, { test: true });
 		});
-		socket.on('got it', () => {
-			socket.disconnect();
-			done();
-		});
-		socket.on('connect', () => {
-			socket.emit('ack');
-		});
+		socket.on('got it', () => done());
+		socket.on('connect', () => socket.emit('ack'));
 	});
 
 	xit('should receive date with ack', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.on('connect', () => {
 			socket.emit('getAckDate', { test: true }, function (data) {
 				expect(data).toBe(jasmine.any(String));
-				socket.disconnect();
 				done();
 			});
 		});
 	});
 
 	it('should work with false', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.on('false', f => {
 			expect(f).toBe(false);
-			socket.disconnect();
 			done();
 		});
-		socket.on('connect', () => {
-			socket.emit('false');
-		});
+		socket.on('connect', () => socket.emit('false'));
 	});
 
 	it('should receive utf8 multibyte characters', done => {
@@ -101,59 +109,50 @@ describe('connection', () => {
 			'utf8 — string'
 		];
 
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		let i = 0;
 		socket.on('takeUtf8', data => {
 			expect(data).toBe(correct[i]);
 			i++;
 			if (i === correct.length) {
-				socket.disconnect();
 				done();
 			}
 		});
-		socket.on('connect', () => {
-			socket.emit('getUtf8');
-		});
+		socket.on('connect', () => socket.emit('getUtf8'));
 	});
 
 	it('should connect to a namespace after connection established', done => {
-		const manager = io.Manager(url);
-		const socket = manager.socket('/');
-		socket.on('connect', () => {
+		manager = io.Manager(url);
+		socket = manager.socket('/');
+		socket.once('connect', () => {
 			const foo = manager.socket('/foo');
-			foo.on('connect', () => {
+			foo.once('connect', () => {
 				foo.close();
-				socket.close();
-				manager.close();
 				done();
 			});
 		});
 	});
 
 	it('should open a new namespace after connection gets closed', done => {
-		const manager = io.Manager(url);
-		const socket = manager.socket('/');
-		socket.on('connect', () => {
+		manager = io.Manager(url);
+		socket = manager.socket('/');
+		socket.once('connect', () => {
 			socket.disconnect();
-		}).on('disconnect', () => {
+		}).once('disconnect', () => {
 			const foo = manager.socket('/foo');
-			foo.on('connect', () => {
+			foo.once('connect', () => {
 				foo.disconnect();
-				manager.close();
 				done();
 			});
 		});
 	});
 
 	it('should reconnect manually', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.once('connect', () => {
 			socket.disconnect();
 		}).once('disconnect', () => {
-			socket.once('connect', () => {
-				socket.disconnect();
-				done();
-			});
+			socket.once('connect', () => done());
 			socket.connect();
 		});
 	});
@@ -163,14 +162,18 @@ describe('connection', () => {
 			pending('test requirements not applicable on iOS');
 		}
 
-		const socket = io.connect(url + '/invalid', { forceNew: true, timeout: 0, reconnectionDelay: 10 });
+		socket = io.connect(url + '/invalid', { forceNew: true, timeout: 0, reconnectionDelay: 10 });
 		socket.on('connect_error', () => {
-			socket.on('reconnect_attempt', () =>  {
-				fail();
-			});
+			function failCase() {
+				done.fail('Fired reconnect_attempt on socket while disconnecting');
+			}
+			socket.on('reconnect_attempt', failCase);
 			socket.disconnect();
 			// set a timeout to let reconnection possibly fire
-			setTimeout(done, 500);
+			setTimeout(() => {
+				socket.off('reconnect_attempt', failCase);
+				done();
+			}, 500);
 		});
 	});
 
@@ -179,14 +182,18 @@ describe('connection', () => {
 			pending('test requirements not applicable on iOS');
 		}
 
-		const socket = io.connect(url + '/invalid', { forceNew: true, timeout: 0, reconnectionDelay: 10 });
+		socket = io.connect(url + '/invalid', { forceNew: true, timeout: 0, reconnectionDelay: 10 });
 		socket.once('reconnect_attempt', () => {
-			socket.on('reconnect_attempt', () => {
-				fail();
-			});
+			function failCase () {
+				done.fail('Fired reconnect_attempt on socket while disconnecting');
+			}
+			socket.on('reconnect_attempt', failCase);
 			socket.disconnect();
 			// set a timeout to let reconnection possibly fire
-			done();
+			setTimeout(() => {
+				socket.off('reconnect_attempt', failCase);
+				done();
+			}, 500);
 		});
 	});
 
@@ -195,20 +202,17 @@ describe('connection', () => {
 			pending('test requirements not applicable on iOS');
 		}
 
-		const socket = io.connect(url + '/invalid', { forceNew: true, timeout: 0, reconnectionDelay: 10 });
+		socket = io.connect(url + '/invalid', { forceNew: true, timeout: 0, reconnectionDelay: 10 });
 		socket.once('reconnect_attempt', () => {
-			socket.on('reconnect_attempt', () => {
-				socket.disconnect();
-				done();
-			});
+			socket.once('reconnect_attempt', ()  => done());
 			socket.disconnect();
 			socket.connect();
 		});
 	});
 
 	xit('should fire reconnect_* events on socket', done => {
-		const manager = io.Manager(url, { reconnection: true, timeout: 0, reconnectionAttempts: 2, reconnectionDelay: 10 });
-		const socket = manager.socket('/timeout_socket');
+		manager = io.Manager(url, { reconnection: true, timeout: 0, reconnectionAttempts: 2, reconnectionDelay: 10 });
+		socket = manager.socket('/timeout_socket');
 
 		let reconnects = 0;
 		const reconnectCb = attempts => {
@@ -219,15 +223,13 @@ describe('connection', () => {
 		socket.on('reconnect_attempt', reconnectCb);
 		socket.on('reconnect_failed', function failed () {
 			expect(reconnects).toBe(2);
-			socket.close();
-			manager.close();
 			done();
 		});
 	});
 
 	xit('should fire reconnecting (on socket) with attempts number when reconnecting twice', done => {
-		const manager = io.Manager(url, { reconnection: true, timeout: 0, reconnectionAttempts: 2, reconnectionDelay: 10 });
-		const socket = manager.socket('/timeout_socket');
+		manager = io.Manager(url, { reconnection: true, timeout: 0, reconnectionAttempts: 2, reconnectionDelay: 10 });
+		socket = manager.socket('/timeout_socket');
 
 		let reconnects = 0;
 		const reconnectCb = attempts => {
@@ -238,44 +240,39 @@ describe('connection', () => {
 		socket.on('reconnecting', reconnectCb);
 		socket.on('reconnect_failed', () => {
 			expect(reconnects).toBe(2);
-			socket.close();
-			manager.close();
 			done();
 		});
 	});
 
 	it('should connect while disconnecting another socket', done => {
-		const manager = io.Manager(url);
-		const socket1 = manager.socket('/foo');
-		socket1.on('connect', () => {
+		manager = io.Manager(url);
+		socket = manager.socket('/foo');
+		socket.on('connect', () => {
 			const socket2 = manager.socket('/asd');
-			socket2.on('connect', done);
-			socket1.disconnect();
+			socket2.once('connect', () => {
+				socket2.disconnect();
+				done();
+			});
+			socket.disconnect();
 		});
 	});
 
 	it('should emit date as string', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.on('takeDate', data => {
-			socket.close();
 			expect(data).toEqual(jasmine.any(String));
 			done();
 		});
-		socket.on('connect', () => {
-			socket.emit('getDate');
-		});
+		socket.on('connect', () => socket.emit('getDate'));
 	});
 
 	it('should emit date in object', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.on('takeDateObj', data => {
-			socket.close();
 			expect(data).toEqual(jasmine.any(Object));
 			expect(data.date).toEqual(jasmine.any(String));
 			done();
 		});
-		socket.on('connect', () => {
-			socket.emit('getDateObj');
-		});
+		socket.on('connect', () => socket.emit('getDateObj'));
 	});
 });

--- a/test/unit/specs/event.spec.js
+++ b/test/unit/specs/event.spec.js
@@ -4,19 +4,21 @@ const port = '3210';
 const url = `http://${host}:${port}`;
 
 describe('event', () => {
-	it('should emit and receive simple events', done => {
-		const socket = io.connect(url, { forceNew: true });
-		socket.on('hi', () => {
+	let socket;
+	afterEach(() => {
+		if (socket && socket.connected) {
 			socket.disconnect();
-			done();
-		});
-		socket.on('connect', () => {
-			socket.emit('hi');
-		});
+		}
+	});
+
+	it('should emit and receive simple events', done => {
+		socket = io.connect(url, { forceNew: true });
+		socket.on('hi', () => done());
+		socket.on('connect', () => socket.emit('hi'));
 	});
 
 	it('should remove all event handlers', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		socket.on('hi', () => {
 			done.fail('Unexpected event');
 		});
@@ -26,15 +28,12 @@ describe('event', () => {
 		socket.on('connect', () => {
 			socket.off();
 			socket.emit('hi');
-			setTimeout(() => {
-				socket.disconnect();
-				done();
-			}, 500);
+			setTimeout(done, 500);
 		});
 	});
 
 	it('should remove all handlers of the specified event', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		const echoSpy = jasmine.createSpy('echo');
 		socket.on('hi', () => {
 			done.fail('Unexpected event');
@@ -46,14 +45,13 @@ describe('event', () => {
 			socket.emit('echo', 'test');
 			setTimeout(() => {
 				expect(echoSpy).toHaveBeenCalled();
-				socket.disconnect();
 				done();
 			}, 500);
 		});
 	});
 
 	it('should remove single event handler', done => {
-		const socket = io.connect(url, { forceNew: true });
+		socket = io.connect(url, { forceNew: true });
 		const firstSpy = jasmine.createSpy('first');
 		const secondSpy = jasmine.createSpy('second');
 		socket.on('hi', firstSpy);
@@ -64,7 +62,6 @@ describe('event', () => {
 			setTimeout(() => {
 				expect(firstSpy).toHaveBeenCalled();
 				expect(secondSpy).not.toHaveBeenCalled();
-				socket.disconnect();
 				done();
 			}, 500);
 		});


### PR DESCRIPTION
The implementation of `once` in the Android JS wrapper was not using the correct reference to `listener` when calling `off` internally. It tried to remove the *original* listener function and not the special wrapper function we generate inside `once` and pass to `on`. As a result, it never matched what was store din the underlying `Map` and always had an undefined listenerId - and therefore never detached the listener in Java native code (`_nativeOff`).