### PR TITLE
feat(android): update socket deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,12 @@
 
 ## Requirements
 
-- [x] Android: Titanium SDK 7.0.0+
+- [x] Android: Titanium SDK 9.0.0+
 - [x] iOS: Titanium SDK 7.4.0+ / Xcode 10.2 / Swift 5.0+
 
 > 💡 The iOS module is built with Swift 5.0 and you need to have the same Swift version installed to be able to use this module. You can check your current Swift version by using swift -v from the terminal.
+
+> 💡 The Android module version 4.x will support Socket.io Server 3.x/4.x
 
 ## Getting started
 
@@ -102,13 +104,12 @@ Based on the [socket.io-client-java](https://github.com/socketio/socket.io-clien
 ## Contributions
 
 Open source contributions are greatly appreciated! If you have a bugfix, improvement or new feature, please create
-[an issue](https://github.com/appcelerator-modules/titanium-socketio/issues/new) first and submit a [pull request](https://github.com/appcelerator-modules/titanium-socketio/pulls/new) against master.
+[an issue](https://github.com/tidev/titanium-socketio/issues/new) first and submit a [pull request](https://github.com/tidev/titanium-socketio/pulls/new) against master.
 
 ## Getting Help
 
 If you have questions about the Socket.IO module for Titanium, feel free to reach out on Stackoverflow or the
-`#helpme` channel on [TiSlack](http://tislack.org). In case you find a bug, create a [new issue](/issues/new)
-or open a [new JIRA ticket](https://jira.appcelerator.org).
+`#helpme` channel on [TiSlack](http://tislack.org). In case you find a bug, create a [new issue](/issues/new).
 
 ## License
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 dependencies {
-	implementation ('io.socket:socket.io-client:1.0.0') {
+	implementation ('io.socket:socket.io-client:2.0.1') {
 	// excluding org.json which is provided by Android
 		exclude group: 'org.json', module: 'json'
 	}

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
 }
 
 dependencies {
-	implementation ('io.socket:socket.io-client:2.0.1') {
+	implementation ('io.socket:socket.io-client:2.1.0') {
 	// excluding org.json which is provided by Android
 		exclude group: 'org.json', module: 'json'
 	}

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.1
+version: 4.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: ti.socketio


### PR DESCRIPTION
Update the socket.io library to 2.0.1 so it will be compatible with Socket.io 3/4: https://github.com/socketio/socket.io-client-java#compatibility

Updated binary: [ti.socketio-android-4.0.0.zip](https://github.com/tidev/titanium-socketio/files/9226942/ti.socketio-android-4.0.0.zip)


Tested with my demo project at https://github.com/m1ga/socket_io_demo
